### PR TITLE
Added line item shipping.

### DIFF
--- a/lib/spree/shipment_notice.rb
+++ b/lib/spree/shipment_notice.rb
@@ -20,8 +20,12 @@ module Spree
 
     def update
       @shipment.update_attribute(:tracking, @tracking)
-      @shipment.reload.update_attribute(:state, 'shipped') unless @shipment.shipped?
 
+      unless @shipment.shipped?
+        @shipment.reload.update_attribute(:state, 'shipped')
+        @shipment.inventory_units.each &:ship!
+        @shipment.touch :shipped_at
+      end
       true
     end
 


### PR DESCRIPTION
This ships individual line items when a shipment is shipped. Without this fix returns can't be processed since the shipment is in an inconsistent state.
