### PR TITLE
Use user.id as CustomerId because emails can go over the 50 char limit

### DIFF
--- a/app/views/spree/shipstation/export.xml.builder
+++ b/app/views/spree/shipstation/export.xml.builder
@@ -46,7 +46,7 @@ xml.Orders {
 =end
 
       xml.Customer {
-        xml.CustomerCode order.email
+        xml.CustomerCode order.user.id
         address(xml, order, :bill)
         address(xml, order, :ship)
       }


### PR DESCRIPTION
A common occurrence of this is when using `spree_social` and the user opts not to share their email, facebook creates a proxy email address that is often over 50 characters long. ShipStation will reject this as the character limit on CustomerID is 50, although for email it is 100. I think user.id is the right field to send as a unique customer ID anyway...
