### PR TITLE
make scope activerecord 4.1 compatible

### DIFF
--- a/app/models/spree/shipment_decorator.rb
+++ b/app/models/spree/shipment_decorator.rb
@@ -1,5 +1,5 @@
 Spree::Shipment.class_eval do
-  scope :exportable, joins(:order).where('spree_shipments.state != ?', 'pending')
+  scope :exportable, -> { joins(:order).where('spree_shipments.state != ?', 'pending') }
 
   def self.between(from, to)
     joins(:order).where('(spree_shipments.updated_at > ? AND spree_shipments.updated_at < ?) OR (spree_orders.updated_at > ? AND spree_orders.updated_at < ?)',from, to, from, to)


### PR DESCRIPTION
this fixes breaking spree 2.3 apps which bump the min rails version to 4.1
