### PR TITLE
Fix For Broken Shipments

### DIFF
--- a/app/views/spree/shipstation/export.xml.builder
+++ b/app/views/spree/shipstation/export.xml.builder
@@ -21,10 +21,17 @@ def address(xml, order, type)
   }
 end
 
+def error(order, shipment)
+  Rails.logger.info "Order #{order.number} is without a proper shipment for ShipStation."
+  next
+end
+
 xml.instruct!
 xml.Orders(pages: (@shipments.total_count/50.0).ceil) {
   @shipments.each do |shipment|
     order = shipment.order
+
+    error(order) if order.completed_at.nil? || shipment.created_at.nil?
 
     xml.Order {
       xml.OrderID        shipment.id
@@ -41,6 +48,7 @@ xml.Orders(pages: (@shipments.total_count/50.0).ceil) {
         xml.CustomField1   "Exchange or Replacement Shipment. Not the first shipment for this order."
       end
       xml.CustomField2   shipment.number
+
 
 =begin
       if order.gift?


### PR DESCRIPTION
When there is an error between timestamps on Order and Shipments
timesamps we rescue this, pass the offending order to the Rails logger
and finish by calling next to loop into the next shipment.
