### PR TITLE
make shipping respect email settings

### DIFF
--- a/app/models/spree/shipment_decorator.rb
+++ b/app/models/spree/shipment_decorator.rb
@@ -3,9 +3,4 @@ Spree::Shipment.class_eval do
   def self.between(from, to)
     joins(:order).where('(spree_shipments.updated_at > ? AND spree_shipments.updated_at < ?) OR (spree_orders.updated_at > ? AND spree_orders.updated_at < ?)',from, to, from, to)
   end
-
-private
-  def send_shipped_email
-    Spree::ShipmentMailer.shipped_email(self).deliver if Spree::Config.send_shipped_email
-  end
 end

--- a/app/models/spree/shipment_handler_decorator.rb
+++ b/app/models/spree/shipment_handler_decorator.rb
@@ -1,0 +1,6 @@
+Spree::ShipmentHandler.class_eval do
+  private
+    def send_shipped_email
+      Spree::ShipmentMailer.shipped_email(@shipment.id).deliver if Spree::Config.send_shipped_email
+    end
+end


### PR DESCRIPTION
shipment email sending is now handled in the ShipmentHandler in spree 2-4-stable

I tried to test against this, but it seems difficult.
